### PR TITLE
Add ProfilePage schema functionality with user selection and meta registration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         php_version: ["8.3","8.4","8.5"]
         wp_version: ["6.9"]
@@ -66,7 +67,7 @@ jobs:
           composer-options: '--prefer-dist --optimize-autoloader'
 
       - name: NPM build
-        run: npm run build
+        run: npm run build -- --stats verbose
 
       - name: Install Playwright dependencies
         run: npx playwright install chromium firefox webkit --with-deps

--- a/dc23-portfolio.php
+++ b/dc23-portfolio.php
@@ -41,12 +41,50 @@ function dc23_portfolio_block_init() {
 }
 add_action( 'init', 'dc23_portfolio_block_init' );
 
+/**
+ * Register post meta for ProfilePage user selection.
+ */
+function dc23_portfolio_register_post_meta() {
+	register_post_meta(
+		'page',
+		'_dc23_portfolio_user_id',
+		array(
+			'type'              => 'integer',
+			'single'            => true,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'absint',
+			'auth_callback'     => function () {
+				return current_user_can( 'edit_posts' );
+			},
+		)
+	);
+}
+add_action( 'init', 'dc23_portfolio_register_post_meta' );
+
+/**
+ * Enqueue ProfilePage schema sidebar script.
+ */
+function dc23_portfolio_enqueue_editor_assets() {
+	$asset_file = include plugin_dir_path( __FILE__ ) . 'build/index.asset.php';
+
+	wp_enqueue_script(
+		'dc23-portfolio-profile-schema',
+		plugins_url( 'build/index.js', __FILE__ ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
+		true
+	);
+}
+add_action( 'enqueue_block_editor_assets', 'dc23_portfolio_enqueue_editor_assets' );
+
 
 /**
  * Initialize schema hooks for portfolio blocks.
  */
 function dc23_portfolio_schema_init() {
 	add_filter( 'wpseo_schema_block_dc23-portfolio/skill', 'dc23_portfolio_skills_to_schema', 10, 3 );
+	add_filter( 'wpseo_schema_webpage', 'dc23_portfolio_schema_webpage', 10, 1 );
+	add_filter( 'wpseo_schema_graph_pieces', 'dc23_portfolio_schema_graph_pieces', 11, 2 );
 	// add_filter( 'wpseo_pre_schema_block_type_dc23-portfolio/education', 'dc23_portfolio_education_to_schema', 10, 3 );
 	// add_filter( 'wpseo_pre_schema_block_type_dc23-portfolio/experience', 'dc23_portfolio_experience_to_schema', 10, 3 );
 }
@@ -113,3 +151,108 @@ function custom_rest_user_profiles() {
 }
 
 add_action('rest_api_init', 'custom_rest_user_profiles');
+
+/**
+ * Modify WebPage schema to add mainEntity and about properties for ProfilePage.
+ *
+ * @param array $data WebPage schema data.
+ * @return array Modified WebPage schema data.
+ */
+function dc23_portfolio_schema_webpage( $data ) {
+	// Only process on singular pages
+	if ( ! is_singular( 'page' ) ) {
+		return $data;
+	}
+
+	// Get the selected user ID from post meta
+	$user_id = get_post_meta( get_the_ID(), '_dc23_portfolio_user_id', true );
+
+	// Return early if no user selected
+	if ( empty( $user_id ) ) {
+		return $data;
+	}
+
+	// Get the user
+	$user = get_userdata( $user_id );
+	if ( ! $user ) {
+		return $data;
+	}
+
+	// Generate the Person @id
+	$person_id = trailingslashit( get_permalink() ) . '#/schema/person/' . $user_id;
+
+	// Add mainEntity and about properties
+	$data['mainEntity'] = array( '@id' => $person_id );
+	$data['about']      = array( '@id' => $person_id );
+
+	return $data;
+}
+
+/**
+ * Add Person schema piece for the selected user.
+ *
+ * @param array $pieces Current schema pieces.
+ * @param \Yoast\WP\SEO\Context\Meta_Tags_Context $context Yoast context.
+ * @return array Modified schema pieces.
+ */
+function dc23_portfolio_schema_graph_pieces( $pieces, $context ) {
+	// Only process on singular pages
+	if ( ! is_singular( 'page' ) ) {
+		return $pieces;
+	}
+
+	// Get the selected user ID from post meta
+	$user_id = get_post_meta( get_the_ID(), '_dc23_portfolio_user_id', true );
+
+	// Return early if no user selected
+	if ( empty( $user_id ) ) {
+		return $pieces;
+	}
+
+	// Get the user
+	$user = get_userdata( $user_id );
+	if ( ! $user ) {
+		return $pieces;
+	}
+
+	// Build Person schema
+	$person_schema = array(
+		'@type' => 'Person',
+		'@id'   => trailingslashit( get_permalink() ) . '#/schema/person/' . $user_id,
+		'name'  => $user->display_name,
+	);
+
+	// Add Yoast SEO Premium profile fields if available
+	$yoast_title = get_user_meta( $user_id, 'wpseo_title', true );
+	if ( ! empty( $yoast_title ) ) {
+		$person_schema['jobTitle'] = $yoast_title;
+	}
+
+	$yoast_pronouns = get_user_meta( $user_id, 'wpseo_pronouns', true );
+	if ( ! empty( $yoast_pronouns ) ) {
+		$person_schema['knowsAbout'] = $yoast_pronouns; // Using knowsAbout as there's no perfect property for pronouns
+	}
+
+	$yoast_employer = get_user_meta( $user_id, 'wpseo_employer', true );
+	if ( ! empty( $yoast_employer ) ) {
+		$person_schema['worksFor'] = array(
+			'@type' => 'Organization',
+			'name'  => $yoast_employer,
+		);
+	}
+
+	// Add email if available
+	if ( ! empty( $user->user_email ) ) {
+		$person_schema['email'] = $user->user_email;
+	}
+
+	// Add URL if available
+	if ( ! empty( $user->user_url ) ) {
+		$person_schema['url'] = $user->user_url;
+	}
+
+	// Add the Person piece to the graph
+	$pieces[] = $person_schema;
+
+	return $pieces;
+}

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -85,7 +85,9 @@ test.describe('ProfilePage Schema', () => {
 		await pageTypeSelect.selectOption('ProfilePage');
 
 		// Wait for ProfilePage Schema section to appear
-		await expect(yoastSidebar.locator('text=ProfilePage Schema')).toBeVisible({ timeout: 5000 });
+		const portfolioTab = yoastSidebar.locator('text=ProfilePage Schema');
+		portfolioTab.scrollIntoViewIfNeeded();
+		await expect(portfolioTab).toBeVisible({ timeout: 5000 });
 	});
 
 	test('can search for users', async ({ page }) => {

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -84,7 +84,9 @@ test.describe('ProfilePage Schema', () => {
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 		await pageTypeSelect.scrollIntoViewIfNeeded();
-		
+		// close tab, trigger change?
+		await schemaTab.click();
+
 		// Wait for ProfilePage Schema section to appear
 		const portfolioTab = yoastSidebar.locator('text=ProfilePage Schema');
 		portfolioTab.scrollIntoViewIfNeeded();

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -81,7 +81,8 @@ test.describe('ProfilePage Schema', () => {
 
 		// Change page type to ProfilePage
 		await page.getByRole('combobox', { name: 'Page type' }).click();
-		await page.getByRole('option').filter({ hasText: 'Profile page' }).click();
+		await page.getByRole('option').filter({ hasText: 'Profile page' }).click({force: true});
+		//await page.getByRole('option', { name: 'Profile page' }).click({force: true});
 /*
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -81,20 +81,22 @@ test.describe('ProfilePage Schema', () => {
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
 		await yoastButton.click();
-		
-		const schemaTab = page.locator('button:has-text("Schema")').first();
+
+		const yoastSidebar =	page.getByRole('region', { name: 'Editor settings' });
+
+		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
-		const pageTypeSelect = page.getByLabel('Page type');
+		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
 		// Wait for ProfilePage Schema section
-		await expect(page.locator('text=ProfilePage Schema')).toBeVisible();
+		await expect(yoastSidebar.locator('text=ProfilePage Schema')).toBeVisible();
 
 		// Find the search input
-		const searchInput = page.locator('input[placeholder*="Search for a user"]').first();
+		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();
 		await searchInput.click();
 		await searchInput.fill('Test Profile');
 
@@ -102,11 +104,11 @@ test.describe('ProfilePage Schema', () => {
 		await page.waitForTimeout(1000); // Wait for API call
 
 		// Check that search results appear
-		const searchResults = page.locator('.dc23-user-search-results');
+		const searchResults = yoastSidebar.locator('.dc23-user-search-results');
 		await expect(searchResults).toBeVisible({ timeout: 3000 });
 		
 		// Check that our test user appears in results
-		await expect(page.locator('text=Test Profile User')).toBeVisible();
+		await expect(yoastSidebar.locator('text=Test Profile User')).toBeVisible();
 	});
 
 	test('can select a user and save to post meta', async ({ page, editor }) => {
@@ -114,27 +116,29 @@ test.describe('ProfilePage Schema', () => {
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
 		await yoastButton.click();
+
+		const yoastSidebar =	page.getByRole('region', { name: 'Editor settings' });
 		
-		const schemaTab = page.locator('button:has-text("Schema")').first();
+		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
-		const pageTypeSelect = page.getByLabel('Page type');
+		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
 		// Search for user
-		const searchInput = page.locator('input[placeholder*="Search for a user"]').first();
+		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();
 		await searchInput.fill('Test Profile');
 		await page.waitForTimeout(1000);
 
 		// Select the user
-		const userButton = page.locator('button.dc23-user-select-button:has-text("Test Profile User")').first();
+		const userButton = yoastSidebar.locator('button.dc23-user-select-button:has-text("Test Profile User")').first();
 		await userButton.click();
 
 		// Wait for user profile to load
-		await expect(page.locator('text=Selected Profile')).toBeVisible({ timeout: 3000 });
-		await expect(page.locator('text=Test Profile User')).toBeVisible();
+		await expect(yoastSidebar.locator('text=Selected Profile')).toBeVisible({ timeout: 3000 });
+		await expect(yoastSidebar.locator('text=Test Profile User')).toBeVisible();
 
 		// Save the post
 		await editor.publishPost();
@@ -149,14 +153,16 @@ test.describe('ProfilePage Schema', () => {
 		const yoastButtonReload = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButtonReload.waitFor({ state: 'visible', timeout: 5000 });
 		await yoastButtonReload.click();
-		
-		const schemaTabReload = page.locator('button:has-text("Schema")').first();
+
+		const yoastSidebarReload =	page.getByRole('region', { name: 'Editor settings' });
+
+		const schemaTabReload = yoastSidebarReload.locator('button:has-text("Schema")').first();
 		await schemaTabReload.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTabReload.click();
 
 		// Check that the selected user is still shown
-		await expect(page.locator('text=Selected Profile')).toBeVisible({ timeout: 5000 });
-		await expect(page.locator('.dc23-user-profile:has-text("Test Profile User")')).toBeVisible();
+		await expect(yoastSidebarReload.locator('text=Selected Profile')).toBeVisible({ timeout: 5000 });
+		await expect(yoastSidebarReload.locator('.dc23-user-profile:has-text("Test Profile User")')).toBeVisible();
 	});
 
 	test('displays user profile information', async ({ page }) => {
@@ -164,25 +170,27 @@ test.describe('ProfilePage Schema', () => {
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
 		await yoastButton.click();
+
+		const yoastSidebar =	page.getByRole('region', { name: 'Editor settings' });
 		
-		const schemaTab = page.locator('button:has-text("Schema")').first();
+		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
-		const pageTypeSelect = page.getByLabel('Page type');
+		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
 		// Search and select user
-		const searchInput = page.locator('input[placeholder*="Search for a user"]').first();
+		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();
 		await searchInput.fill('Test Profile');
 		await page.waitForTimeout(1000);
 
-		const userButton = page.locator('button.dc23-user-select-button:has-text("Test Profile User")').first();
+		const userButton = yoastSidebar.locator('button.dc23-user-select-button:has-text("Test Profile User")').first();
 		await userButton.click();
 
 		// Check that user info is displayed
-		const userProfile = page.locator('.dc23-user-profile');
+		const userProfile = yoastSidebar.locator('.dc23-user-profile');
 		await expect(userProfile).toBeVisible();
 		
 		// Check for name
@@ -195,32 +203,34 @@ test.describe('ProfilePage Schema', () => {
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
 		await yoastButton.click();
+
+		const yoastSidebar =	page.getByRole('region', { name: 'Editor settings' });
 		
-		const schemaTab = page.locator('button:has-text("Schema")').first();
+		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
-		const pageTypeSelect = page.getByLabel('Page type');
+		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
 		// Search for user
-		const searchInput = page.locator('input[placeholder*="Search for a user"]').first();
+		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();
 		await searchInput.fill('Test Profile');
 		await page.waitForTimeout(1000);
 
 		// Verify search results are visible
-		await expect(page.locator('.dc23-user-search-results')).toBeVisible();
+		await expect(yoastSidebar.locator('.dc23-user-search-results')).toBeVisible();
 
 		// Select the user
-		const userButton = page.locator('button.dc23-user-select-button:has-text("Test Profile User")').first();
+		const userButton = yoastSidebar.locator('button.dc23-user-select-button:has-text("Test Profile User")').first();
 		await userButton.click();
 
 		// Wait a moment for state update
 		await page.waitForTimeout(500);
 
 		// Verify search results are cleared
-		await expect(page.locator('.dc23-user-search-results')).not.toBeVisible({ timeout: 2000 });
+		await expect(yoastSidebar.locator('.dc23-user-search-results')).not.toBeVisible({ timeout: 2000 });
 	});
 
 	test('only shows for pages, not posts', async ({ admin, page }) => {
@@ -238,13 +248,15 @@ test.describe('ProfilePage Schema', () => {
 		if (await settingsButton.isVisible()) {
 			await settingsButton.click();
 		}
-		
-		const schemaTab = page.locator('button:has-text("Schema")').first();
+
+		const yoastSidebar =	page.getByRole('region', { name: 'Editor settings' });
+
+		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		if (await schemaTab.isVisible()) {
 			await schemaTab.click();
 		
 			// Try to set article type to ProfilePage (if the option even exists for posts)
-			const pageTypeSelect = page.getByLabel('Page type');
+			const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 			if (await pageTypeSelect.isVisible()) {
 				const hasProfilePage = await pageTypeSelect.locator('option[value="ProfilePage"]').count();
 				
@@ -252,7 +264,7 @@ test.describe('ProfilePage Schema', () => {
 					await pageTypeSelect.selectOption('ProfilePage');
 					
 					// ProfilePage Schema section should still not appear for posts
-					await expect(page.locator('text=ProfilePage Schema')).not.toBeVisible({ timeout: 2000 });
+					await expect(yoastSidebar.locator('text=ProfilePage Schema')).not.toBeVisible({ timeout: 2000 });
 				}
 			}
 		}

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -82,7 +82,9 @@ test.describe('ProfilePage Schema', () => {
 		// Change page type to ProfilePage
 		await page.getByRole('combobox', { name: 'Page type' }).click();
 		//await page.getByRole('option').filter({ hasText: 'Profile page' }).click({force: true});
-		await page.getByRole('option', { name: 'Profile Page' }).click();
+		//await page.getByRole('option', { name: 'Profile Page' }).click();
+		await page.keyboard.type('profi');
+		await page.keyboard.press('Tab'); // Or enter
 /*
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -81,8 +81,8 @@ test.describe('ProfilePage Schema', () => {
 
 		// Change page type to ProfilePage
 		await page.getByRole('combobox', { name: 'Page type' }).click();
-		await page.getByRole('option').filter({ hasText: 'Profile page' }).click({force: true});
-		//await page.getByRole('option', { name: 'Profile page' }).click({force: true});
+		//await page.getByRole('option').filter({ hasText: 'Profile page' }).click({force: true});
+		await page.getByRole('option', { name: 'Profile page' }).click({force: true});
 /*
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -80,12 +80,16 @@ test.describe('ProfilePage Schema', () => {
 		await schemaTab.scrollIntoViewIfNeeded();
 
 		// Change page type to ProfilePage
+		await page.getByRole('combobox', { name: 'Page type' }).click();
+		await page.getByRole('option').filter({ hasText: 'Profile page' }).click();
+/*
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 		await pageTypeSelect.scrollIntoViewIfNeeded();
 		// close tab, trigger change?
 		await schemaTab.click();
+*/
 
 		// Wait for ProfilePage Schema section to appear
 		const portfolioTab = yoastSidebar.locator('text=ProfilePage Schema');

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -66,7 +66,7 @@ test.describe('ProfilePage Schema', () => {
 		await schemaTab.click();
 
 		// Change page type to ProfilePage
-		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		const pageTypeSelect = page.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
@@ -84,7 +84,7 @@ test.describe('ProfilePage Schema', () => {
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
-		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		const pageTypeSelect = page.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
@@ -117,7 +117,7 @@ test.describe('ProfilePage Schema', () => {
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
-		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		const pageTypeSelect = page.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
@@ -167,7 +167,7 @@ test.describe('ProfilePage Schema', () => {
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
-		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		const pageTypeSelect = page.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
@@ -198,7 +198,7 @@ test.describe('ProfilePage Schema', () => {
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
-		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		const pageTypeSelect = page.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
@@ -242,7 +242,7 @@ test.describe('ProfilePage Schema', () => {
 			await schemaTab.click();
 		
 			// Try to set article type to ProfilePage (if the option even exists for posts)
-			const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+			const pageTypeSelect = page.getByLabel('Page type');
 			if (await pageTypeSelect.isVisible()) {
 				const hasProfilePage = await pageTypeSelect.locator('option[value="ProfilePage"]').count();
 				

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -83,7 +83,8 @@ test.describe('ProfilePage Schema', () => {
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
-
+		await pageTypeSelect.scrollIntoViewIfNeeded();
+		
 		// Wait for ProfilePage Schema section to appear
 		const portfolioTab = yoastSidebar.locator('text=ProfilePage Schema');
 		portfolioTab.scrollIntoViewIfNeeded();
@@ -106,7 +107,8 @@ test.describe('ProfilePage Schema', () => {
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
-
+		await pageTypeSelect.scrollIntoViewIfNeeded();
+		
 		// Wait for ProfilePage Schema section
 		await expect(yoastSidebar.locator('text=ProfilePage Schema')).toBeVisible();
 
@@ -142,7 +144,8 @@ test.describe('ProfilePage Schema', () => {
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
-
+		await pageTypeSelect.scrollIntoViewIfNeeded();
+		
 		// Search for user
 		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();
 		await searchInput.fill('Test Profile');
@@ -197,7 +200,8 @@ test.describe('ProfilePage Schema', () => {
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
-
+		await pageTypeSelect.scrollIntoViewIfNeeded();
+		
 		// Search and select user
 		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();
 		await searchInput.fill('Test Profile');
@@ -276,6 +280,7 @@ test.describe('ProfilePage Schema', () => {
 		
 			// Try to set article type to ProfilePage (if the option even exists for posts)
 			const pageTypeSelect = yoastSidebar.getByLabel('Page type');
+			await pageTypeSelect.scrollIntoViewIfNeeded();
 			if (await pageTypeSelect.isVisible()) {
 				const hasProfilePage = await pageTypeSelect.locator('option[value="ProfilePage"]').count();
 				

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -59,19 +59,21 @@ test.describe('ProfilePage Schema', () => {
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
 		await yoastButton.click();
+		
+		const yoastSidebar =	page.getByRole('region', { name: 'Editor settings' });
 
 		// Navigate to Schema tab
-		const schemaTab = page.locator('button:has-text("Schema")').first();
+		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 
 		// Change page type to ProfilePage
-		const pageTypeSelect = page.getByLabel('Page type');
+		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
 		// Wait for ProfilePage Schema section to appear
-		await expect(page.locator('text=ProfilePage Schema')).toBeVisible({ timeout: 5000 });
+		await expect(yoastSidebar.locator('text=ProfilePage Schema')).toBeVisible({ timeout: 5000 });
 	});
 
 	test('can search for users', async ({ page }) => {

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -98,7 +98,7 @@ test.describe('ProfilePage Schema', () => {
 		await expect(portfolioTab).toBeVisible({ timeout: 5000 });
 	});
 
-	test('can search for users', async ({ page }) => {
+	test.skip('can search for users', async ({ page }) => {
 		// Open Yoast SEO sidebar and set page type to ProfilePage
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
@@ -135,7 +135,7 @@ test.describe('ProfilePage Schema', () => {
 		await expect(yoastSidebar.locator('text=Test Profile User')).toBeVisible();
 	});
 
-	test('can select a user and save to post meta', async ({ page, editor }) => {
+	test.skip('can select a user and save to post meta', async ({ page, editor }) => {
 		// Open Yoast SEO sidebar and set page type to ProfilePage
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
@@ -191,7 +191,7 @@ test.describe('ProfilePage Schema', () => {
 		await expect(yoastSidebarReload.locator('.dc23-user-profile:has-text("Test Profile User")')).toBeVisible();
 	});
 
-	test('displays user profile information', async ({ page }) => {
+	test.skip('displays user profile information', async ({ page }) => {
 		// Open Yoast SEO sidebar and set page type to ProfilePage
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
@@ -226,7 +226,7 @@ test.describe('ProfilePage Schema', () => {
 		await expect(userProfile).toContainText('Test Profile User');
 	});
 
-	test('clears search results after user selection', async ({ page }) => {
+	test.skip('clears search results after user selection', async ({ page }) => {
 		// Open Yoast SEO sidebar and set page type to ProfilePage
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -1,0 +1,241 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
+
+test.describe('ProfilePage Schema', () => {
+	let testUserId;
+	
+	test.beforeAll(async ({ requestUtils }) => {
+		// Create a test user for selection
+		const user = await requestUtils.rest({
+			method: 'POST',
+			path: '/wp/v2/users',
+			data: {
+				username: 'testprofileuser',
+				email: 'testprofile@example.com',
+				password: 'TestPassword123!',
+				name: 'Test Profile User',
+				roles: ['author'],
+			},
+		});
+		testUserId = user.id;
+	});
+
+	test.afterAll(async ({ requestUtils }) => {
+		// Clean up test user
+		if (testUserId) {
+			await requestUtils.rest({
+				method: 'DELETE',
+				path: `/wp/v2/users/${testUserId}`,
+				data: { force: true, reassign: 1 },
+			});
+		}
+	});
+
+	test.beforeEach(async ({ admin }) => {
+		await admin.createNewPost({ postType: 'page' });
+	});
+
+	test('ProfilePage Schema section does not appear by default', async ({ page, editor }) => {
+		// Open the Yoast SEO sidebar (if not already open)
+		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
+		if (await yoastButton.isVisible()) {
+			await yoastButton.click();
+		}
+
+		// Check that ProfilePage Schema section is not visible
+		await expect(page.locator('text=ProfilePage Schema')).not.toBeVisible({ timeout: 2000 });
+	});
+
+	test('ProfilePage Schema section appears when page type is ProfilePage', async ({ page }) => {
+		// Open Yoast SEO settings
+		const settingsButton = page.locator('button[aria-label*="Settings"]').first();
+		if (await settingsButton.isVisible()) {
+			await settingsButton.click();
+		}
+
+		// Navigate to Schema tab
+		const schemaTab = page.locator('button:has-text("Schema")').first();
+		await schemaTab.click();
+
+		// Change page type to ProfilePage
+		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		await pageTypeSelect.selectOption('ProfilePage');
+
+		// Wait for ProfilePage Schema section to appear
+		await expect(page.locator('text=ProfilePage Schema')).toBeVisible({ timeout: 5000 });
+	});
+
+	test('can search for users', async ({ page }) => {
+		// Set page type to ProfilePage
+		const settingsButton = page.locator('button[aria-label*="Settings"]').first();
+		if (await settingsButton.isVisible()) {
+			await settingsButton.click();
+		}
+		
+		const schemaTab = page.locator('button:has-text("Schema")').first();
+		await schemaTab.click();
+		
+		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		await pageTypeSelect.selectOption('ProfilePage');
+
+		// Wait for ProfilePage Schema section
+		await expect(page.locator('text=ProfilePage Schema')).toBeVisible();
+
+		// Find the search input
+		const searchInput = page.locator('input[placeholder*="Search for a user"]').first();
+		await searchInput.click();
+		await searchInput.fill('Test Profile');
+
+		// Wait for search results
+		await page.waitForTimeout(1000); // Wait for API call
+
+		// Check that search results appear
+		const searchResults = page.locator('.dc23-user-search-results');
+		await expect(searchResults).toBeVisible({ timeout: 3000 });
+		
+		// Check that our test user appears in results
+		await expect(page.locator('text=Test Profile User')).toBeVisible();
+	});
+
+	test('can select a user and save to post meta', async ({ page, editor }) => {
+		// Set page type to ProfilePage
+		const settingsButton = page.locator('button[aria-label*="Settings"]').first();
+		if (await settingsButton.isVisible()) {
+			await settingsButton.click();
+		}
+		
+		const schemaTab = page.locator('button:has-text("Schema")').first();
+		await schemaTab.click();
+		
+		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		await pageTypeSelect.selectOption('ProfilePage');
+
+		// Search for user
+		const searchInput = page.locator('input[placeholder*="Search for a user"]').first();
+		await searchInput.fill('Test Profile');
+		await page.waitForTimeout(1000);
+
+		// Select the user
+		const userButton = page.locator('button.dc23-user-select-button:has-text("Test Profile User")').first();
+		await userButton.click();
+
+		// Wait for user profile to load
+		await expect(page.locator('text=Selected Profile')).toBeVisible({ timeout: 3000 });
+		await expect(page.locator('text=Test Profile User')).toBeVisible();
+
+		// Save the post
+		await editor.publishPost();
+
+		// Verify the meta was saved by reloading and checking
+		await page.reload();
+		
+		// Wait for editor to load
+		await page.waitForLoadState('domcontentloaded');
+		
+		// Open Yoast SEO and Schema tab again
+		const settingsButtonReload = page.locator('button[aria-label*="Settings"]').first();
+		if (await settingsButtonReload.isVisible()) {
+			await settingsButtonReload.click();
+		}
+		
+		const schemaTabReload = page.locator('button:has-text("Schema")').first();
+		await schemaTabReload.click();
+
+		// Check that the selected user is still shown
+		await expect(page.locator('text=Selected Profile')).toBeVisible({ timeout: 5000 });
+		await expect(page.locator('.dc23-user-profile:has-text("Test Profile User")')).toBeVisible();
+	});
+
+	test('displays user profile information', async ({ page }) => {
+		// Set page type to ProfilePage
+		const settingsButton = page.locator('button[aria-label*="Settings"]').first();
+		if (await settingsButton.isVisible()) {
+			await settingsButton.click();
+		}
+		
+		const schemaTab = page.locator('button:has-text("Schema")').first();
+		await schemaTab.click();
+		
+		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		await pageTypeSelect.selectOption('ProfilePage');
+
+		// Search and select user
+		const searchInput = page.locator('input[placeholder*="Search for a user"]').first();
+		await searchInput.fill('Test Profile');
+		await page.waitForTimeout(1000);
+
+		const userButton = page.locator('button.dc23-user-select-button:has-text("Test Profile User")').first();
+		await userButton.click();
+
+		// Check that user info is displayed
+		const userProfile = page.locator('.dc23-user-profile');
+		await expect(userProfile).toBeVisible();
+		
+		// Check for name
+		await expect(userProfile.locator('text=Name:')).toBeVisible();
+		await expect(userProfile).toContainText('Test Profile User');
+	});
+
+	test('clears search results after user selection', async ({ page }) => {
+		// Set page type to ProfilePage
+		const settingsButton = page.locator('button[aria-label*="Settings"]').first();
+		if (await settingsButton.isVisible()) {
+			await settingsButton.click();
+		}
+		
+		const schemaTab = page.locator('button:has-text("Schema")').first();
+		await schemaTab.click();
+		
+		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		await pageTypeSelect.selectOption('ProfilePage');
+
+		// Search for user
+		const searchInput = page.locator('input[placeholder*="Search for a user"]').first();
+		await searchInput.fill('Test Profile');
+		await page.waitForTimeout(1000);
+
+		// Verify search results are visible
+		await expect(page.locator('.dc23-user-search-results')).toBeVisible();
+
+		// Select the user
+		const userButton = page.locator('button.dc23-user-select-button:has-text("Test Profile User")').first();
+		await userButton.click();
+
+		// Wait a moment for state update
+		await page.waitForTimeout(500);
+
+		// Verify search results are cleared
+		await expect(page.locator('.dc23-user-search-results')).not.toBeVisible({ timeout: 2000 });
+	});
+
+	test('only shows for pages, not posts', async ({ admin, page }) => {
+		// Create a regular post instead of a page
+		await admin.createNewPost({ postType: 'post' });
+
+		// Open Yoast SEO if available
+		const settingsButton = page.locator('button[aria-label*="Settings"]').first();
+		if (await settingsButton.isVisible()) {
+			await settingsButton.click();
+		}
+		
+		const schemaTab = page.locator('button:has-text("Schema")').first();
+		if (await schemaTab.isVisible()) {
+			await schemaTab.click();
+		
+			// Try to set article type to ProfilePage (if the option even exists for posts)
+			const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+			if (await pageTypeSelect.isVisible()) {
+				const hasProfilePage = await pageTypeSelect.locator('option[value="ProfilePage"]').count();
+				
+				if (hasProfilePage > 0) {
+					await pageTypeSelect.selectOption('ProfilePage');
+					
+					// ProfilePage Schema section should still not appear for posts
+					await expect(page.locator('text=ProfilePage Schema')).not.toBeVisible({ timeout: 2000 });
+				}
+			}
+		}
+	});
+});

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -5,6 +5,7 @@ const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
 
 test.describe('ProfilePage Schema', () => {
 	let testUserId;
+	let consoleLogs = [];
 	
 	test.beforeAll(async ({ requestUtils }) => {
 		// Create a test user for selection
@@ -34,6 +35,9 @@ test.describe('ProfilePage Schema', () => {
 	});
 
 	test.beforeEach(async ({ admin, page }) => {
+	 consoleLogs = [];
+  page.on('console', msg => consoleLogs.push(msg.text()));
+
 		await admin.createNewPost({ postType: 'page' });
 		
 		// Close the patterns modal if it appears
@@ -43,6 +47,13 @@ test.describe('ProfilePage Schema', () => {
 		}
 	});
 
+	test.afterEach(async ({ admin, page }) => {
+		if (consoleLogs.length > 0) {
+			console.log('Page logs:', consoleLogs);
+		}
+		page.removeAllListeners('console');
+	});
+	
 	test('ProfilePage Schema section does not appear by default', async ({ page, editor }) => {
 		// Open the Yoast SEO sidebar (if not already open)
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -82,7 +82,7 @@ test.describe('ProfilePage Schema', () => {
 		// Change page type to ProfilePage
 		await page.getByRole('combobox', { name: 'Page type' }).click();
 		//await page.getByRole('option').filter({ hasText: 'Profile page' }).click({force: true});
-		await page.getByRole('option', { name: 'Profile page' }).click({force: true});
+		await page.getByRole('option', { name: 'Profile Page' }).click({force: true});
 /*
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -82,7 +82,7 @@ test.describe('ProfilePage Schema', () => {
 		// Change page type to ProfilePage
 		await page.getByRole('combobox', { name: 'Page type' }).click();
 		//await page.getByRole('option').filter({ hasText: 'Profile page' }).click({force: true});
-		await page.getByRole('option', { name: 'Profile Page' }).click({force: true});
+		await page.getByRole('option', { name: 'Profile Page' }).click();
 /*
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -66,6 +66,7 @@ test.describe('ProfilePage Schema', () => {
 		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
+		await schemaTab.scrollIntoViewIfNeeded();
 
 		// Change page type to ProfilePage
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
@@ -87,7 +88,8 @@ test.describe('ProfilePage Schema', () => {
 		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
-		
+		await schemaTab.scrollIntoViewIfNeeded();
+
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
@@ -122,6 +124,7 @@ test.describe('ProfilePage Schema', () => {
 		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
+		await schemaTab.scrollIntoViewIfNeeded();
 		
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
@@ -176,6 +179,7 @@ test.describe('ProfilePage Schema', () => {
 		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
+		await schemaTab.scrollIntoViewIfNeeded();
 		
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
@@ -209,6 +213,7 @@ test.describe('ProfilePage Schema', () => {
 		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
+		await schemaTab.scrollIntoViewIfNeeded();
 		
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
@@ -254,6 +259,7 @@ test.describe('ProfilePage Schema', () => {
 		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		if (await schemaTab.isVisible()) {
 			await schemaTab.click();
+			await schemaTab.scrollIntoViewIfNeeded();
 		
 			// Try to set article type to ProfilePage (if the option even exists for posts)
 			const pageTypeSelect = yoastSidebar.getByLabel('Page type');

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -33,8 +33,14 @@ test.describe('ProfilePage Schema', () => {
 		}
 	});
 
-	test.beforeEach(async ({ admin }) => {
+	test.beforeEach(async ({ admin, page }) => {
 		await admin.createNewPost({ postType: 'page' });
+		
+		// Close the patterns modal if it appears
+		const closeButton = page.locator('button[aria-label="Close"]').first();
+		if (await closeButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+			await closeButton.click();
+		}
 	});
 
 	test('ProfilePage Schema section does not appear by default', async ({ page, editor }) => {
@@ -49,18 +55,19 @@ test.describe('ProfilePage Schema', () => {
 	});
 
 	test('ProfilePage Schema section appears when page type is ProfilePage', async ({ page }) => {
-		// Open Yoast SEO settings
-		const settingsButton = page.locator('button[aria-label*="Settings"]').first();
-		if (await settingsButton.isVisible()) {
-			await settingsButton.click();
-		}
+		// Open the Yoast SEO sidebar
+		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
+		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
+		await yoastButton.click();
 
 		// Navigate to Schema tab
 		const schemaTab = page.locator('button:has-text("Schema")').first();
+		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 
 		// Change page type to ProfilePage
 		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
 		// Wait for ProfilePage Schema section to appear
@@ -68,16 +75,17 @@ test.describe('ProfilePage Schema', () => {
 	});
 
 	test('can search for users', async ({ page }) => {
-		// Set page type to ProfilePage
-		const settingsButton = page.locator('button[aria-label*="Settings"]').first();
-		if (await settingsButton.isVisible()) {
-			await settingsButton.click();
-		}
+		// Open Yoast SEO sidebar and set page type to ProfilePage
+		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
+		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
+		await yoastButton.click();
 		
 		const schemaTab = page.locator('button:has-text("Schema")').first();
+		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
 		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
 		// Wait for ProfilePage Schema section
@@ -100,16 +108,17 @@ test.describe('ProfilePage Schema', () => {
 	});
 
 	test('can select a user and save to post meta', async ({ page, editor }) => {
-		// Set page type to ProfilePage
-		const settingsButton = page.locator('button[aria-label*="Settings"]').first();
-		if (await settingsButton.isVisible()) {
-			await settingsButton.click();
-		}
+		// Open Yoast SEO sidebar and set page type to ProfilePage
+		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
+		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
+		await yoastButton.click();
 		
 		const schemaTab = page.locator('button:has-text("Schema")').first();
+		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
 		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
 		// Search for user
@@ -135,12 +144,12 @@ test.describe('ProfilePage Schema', () => {
 		await page.waitForLoadState('domcontentloaded');
 		
 		// Open Yoast SEO and Schema tab again
-		const settingsButtonReload = page.locator('button[aria-label*="Settings"]').first();
-		if (await settingsButtonReload.isVisible()) {
-			await settingsButtonReload.click();
-		}
+		const yoastButtonReload = page.locator('button[aria-label*="Yoast"]').first();
+		await yoastButtonReload.waitFor({ state: 'visible', timeout: 5000 });
+		await yoastButtonReload.click();
 		
 		const schemaTabReload = page.locator('button:has-text("Schema")').first();
+		await schemaTabReload.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTabReload.click();
 
 		// Check that the selected user is still shown
@@ -149,16 +158,17 @@ test.describe('ProfilePage Schema', () => {
 	});
 
 	test('displays user profile information', async ({ page }) => {
-		// Set page type to ProfilePage
-		const settingsButton = page.locator('button[aria-label*="Settings"]').first();
-		if (await settingsButton.isVisible()) {
-			await settingsButton.click();
-		}
+		// Open Yoast SEO sidebar and set page type to ProfilePage
+		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
+		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
+		await yoastButton.click();
 		
 		const schemaTab = page.locator('button:has-text("Schema")').first();
+		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
 		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
 		// Search and select user
@@ -179,16 +189,17 @@ test.describe('ProfilePage Schema', () => {
 	});
 
 	test('clears search results after user selection', async ({ page }) => {
-		// Set page type to ProfilePage
-		const settingsButton = page.locator('button[aria-label*="Settings"]').first();
-		if (await settingsButton.isVisible()) {
-			await settingsButton.click();
-		}
+		// Open Yoast SEO sidebar and set page type to ProfilePage
+		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
+		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
+		await yoastButton.click();
 		
 		const schemaTab = page.locator('button:has-text("Schema")').first();
+		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		
 		const pageTypeSelect = page.locator('select[name*="pageType"], select[name*="articleType"]').first();
+		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 
 		// Search for user
@@ -213,6 +224,12 @@ test.describe('ProfilePage Schema', () => {
 	test('only shows for pages, not posts', async ({ admin, page }) => {
 		// Create a regular post instead of a page
 		await admin.createNewPost({ postType: 'post' });
+		
+		// Close any modal that might appear
+		const closeButton = page.locator('button[aria-label="Close"]').first();
+		if (await closeButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+			await closeButton.click();
+		}
 
 		// Open Yoast SEO if available
 		const settingsButton = page.locator('button[aria-label*="Settings"]').first();

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -129,7 +129,7 @@ test.describe('ProfilePage Schema', () => {
 		await expect(yoastSidebar.locator('text=Test Profile User')).toBeVisible();
 	});
 
-	test.skip('can select a user and save to post meta', async ({ page, editor }) => {
+	test('can select a user and save to post meta', async ({ page, editor }) => {
 		// Open Yoast SEO sidebar and set page type to ProfilePage
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
@@ -142,10 +142,15 @@ test.describe('ProfilePage Schema', () => {
 		await schemaTab.click();
 		await schemaTab.scrollIntoViewIfNeeded();
 
-		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
-		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
-		await pageTypeSelect.selectOption('ProfilePage');
-		await pageTypeSelect.scrollIntoViewIfNeeded();
+		// Change page type to ProfilePage
+		await yoastSidebar.getByRole('combobox', { name: 'Page type' }).click();
+		await page.keyboard.type('profi');
+		await page.keyboard.press('Tab');
+		await page.keyboard.press('Tab');
+
+		// Wait for ProfilePage Schema section
+		const portfolioTab = yoastSidebar.locator('button:has-text("ProfilePage Schema")');
+		await expect(portfolioTab).toBeVisible();
 
 		// Search for user
 		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -182,7 +182,8 @@ test.describe('ProfilePage Schema', () => {
 
 		const schemaTabReload = yoastSidebarReload.locator('button:has-text("ProfilePage Schema")').first();
 		await schemaTabReload.waitFor({ state: 'visible', timeout: 5000 });
-		await schemaTabReload.click();
+
+		// await schemaTabReload.click();
 
 		// Check that the selected user is still shown
 		await expect(yoastSidebarReload.locator('text=Selected Profile')).toBeVisible({ timeout: 5000 });

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -41,6 +41,7 @@ test.describe('ProfilePage Schema', () => {
 		await admin.createNewPost({
 			title: 'Test page for ProfilePage markup',
 			postType: 'page',
+			content: 'This page is about our author. Its a more extensive version of their bio, with some hostoric highlights.',
 		});
 
 		// Close the patterns modal if it appears

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -5,7 +5,6 @@ const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
 
 test.describe('ProfilePage Schema', () => {
 	let testUserId;
-	let consoleLogs = [];
 
 	test.beforeAll(async ({ requestUtils }) => {
 		// Create a test user for selection
@@ -35,9 +34,6 @@ test.describe('ProfilePage Schema', () => {
 	});
 
 	test.beforeEach(async ({ admin, page }) => {
-	 consoleLogs = [];
-  page.on('console', msg => consoleLogs.push(msg.text()));
-
 		await admin.createNewPost({
 			title: 'Test page for ProfilePage markup',
 			postType: 'page',
@@ -49,13 +45,6 @@ test.describe('ProfilePage Schema', () => {
 		if (await closeButton.isVisible({ timeout: 2000 }).catch(() => false)) {
 			await closeButton.click();
 		}
-	});
-
-	test.afterEach(async ({ admin, page }) => {
-		if (consoleLogs.length > 0) {
-			console.log('Page logs:', consoleLogs);
-		}
-		page.removeAllListeners('console');
 	});
 
 	test('ProfilePage Schema section does not appear by default', async ({ page, editor }) => {

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -178,9 +178,9 @@ test.describe('ProfilePage Schema', () => {
 		await page.waitForLoadState('domcontentloaded');
 
 		// Close the patterns modal if it appears
-		const closeButton = page.locator('button[aria-label="Close"]').first();
-		if (await closeButton.isVisible({ timeout: 2000 }).catch(() => false)) {
-			await closeButton.click();
+		const patternModalTitle = page.locateByText('Choose a pattern').first();
+		if (await patternModalTitle.isVisible({ timeout: 2000 }).catch(() => false)) {
+			await page.keyboard.press('Escape');
 		}
 
 		// Open Yoast SEO and Schema tab again

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -81,25 +81,15 @@ test.describe('ProfilePage Schema', () => {
 
 		// Change page type to ProfilePage
 		await page.getByRole('combobox', { name: 'Page type' }).click();
-		//await page.getByRole('option').filter({ hasText: 'Profile page' }).click({force: true});
-		//await page.getByRole('option', { name: 'Profile Page' }).click();
 		await page.keyboard.type('profi');
-		await page.keyboard.press('Tab'); // Or enter
-/*
-		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
-		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
-		await pageTypeSelect.selectOption('ProfilePage');
-		await pageTypeSelect.scrollIntoViewIfNeeded();
-		// close tab, trigger change?
-		await schemaTab.click();
-*/
+		await page.keyboard.press('Tab');
 
 		// Wait for ProfilePage Schema section to appear
 		const portfolioTab = yoastSidebar.locator('text=ProfilePage Schema');
 		await expect(portfolioTab).toBeVisible({ timeout: 5000 });
 	});
 
-	test.skip('can search for users', async ({ page }) => {
+	test('can search for users', async ({ page }) => {
 		// Open Yoast SEO sidebar and set page type to ProfilePage
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
@@ -112,10 +102,10 @@ test.describe('ProfilePage Schema', () => {
 		await schemaTab.click();
 		await schemaTab.scrollIntoViewIfNeeded();
 
-		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
-		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
-		await pageTypeSelect.selectOption('ProfilePage');
-		await pageTypeSelect.scrollIntoViewIfNeeded();
+		// Change page type to ProfilePage
+		await page.getByRole('combobox', { name: 'Page type' }).click();
+		await page.keyboard.type('profi');
+		await page.keyboard.press('Tab');
 
 		// Wait for ProfilePage Schema section
 		await expect(yoastSidebar.locator('text=ProfilePage Schema')).toBeVisible();

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -38,7 +38,10 @@ test.describe('ProfilePage Schema', () => {
 	 consoleLogs = [];
   page.on('console', msg => consoleLogs.push(msg.text()));
 
-		await admin.createNewPost({ postType: 'page' });
+		await admin.createNewPost({
+			title: 'Test page for ProfilePage markup',
+			postType: 'page',
+		});
 
 		// Close the patterns modal if it appears
 		const closeButton = page.locator('button[aria-label="Close"]').first();

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -190,7 +190,7 @@ test.describe('ProfilePage Schema', () => {
 		await expect(yoastSidebarReload.locator('.dc23-user-profile:has-text("Test Profile User")')).toBeVisible();
 	});
 
-	test.skip('displays user profile information', async ({ page }) => {
+	test('displays user profile information', async ({ page }) => {
 		// Open Yoast SEO sidebar and set page type to ProfilePage
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
@@ -203,10 +203,11 @@ test.describe('ProfilePage Schema', () => {
 		await schemaTab.click();
 		await schemaTab.scrollIntoViewIfNeeded();
 
-		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
-		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
-		await pageTypeSelect.selectOption('ProfilePage');
-		await pageTypeSelect.scrollIntoViewIfNeeded();
+		// Change page type to ProfilePage
+		await yoastSidebar.getByRole('combobox', { name: 'Page type' }).click();
+		await page.keyboard.type('profi');
+		await page.keyboard.press('Tab');
+		await page.keyboard.press('Tab');
 
 		// Search and select user
 		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -6,7 +6,7 @@ const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
 test.describe('ProfilePage Schema', () => {
 	let testUserId;
 	let consoleLogs = [];
-	
+
 	test.beforeAll(async ({ requestUtils }) => {
 		// Create a test user for selection
 		const user = await requestUtils.rest({
@@ -39,7 +39,7 @@ test.describe('ProfilePage Schema', () => {
   page.on('console', msg => consoleLogs.push(msg.text()));
 
 		await admin.createNewPost({ postType: 'page' });
-		
+
 		// Close the patterns modal if it appears
 		const closeButton = page.locator('button[aria-label="Close"]').first();
 		if (await closeButton.isVisible({ timeout: 2000 }).catch(() => false)) {
@@ -53,7 +53,7 @@ test.describe('ProfilePage Schema', () => {
 		}
 		page.removeAllListeners('console');
 	});
-	
+
 	test('ProfilePage Schema section does not appear by default', async ({ page, editor }) => {
 		// Open the Yoast SEO sidebar (if not already open)
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
@@ -70,7 +70,7 @@ test.describe('ProfilePage Schema', () => {
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
 		await yoastButton.click();
-		
+
 		const yoastSidebar =	page.getByRole('region', { name: 'Editor settings' });
 
 		// Navigate to Schema tab
@@ -96,7 +96,6 @@ test.describe('ProfilePage Schema', () => {
 
 		// Wait for ProfilePage Schema section to appear
 		const portfolioTab = yoastSidebar.locator('text=ProfilePage Schema');
-		portfolioTab.scrollIntoViewIfNeeded();
 		await expect(portfolioTab).toBeVisible({ timeout: 5000 });
 	});
 
@@ -117,7 +116,7 @@ test.describe('ProfilePage Schema', () => {
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 		await pageTypeSelect.scrollIntoViewIfNeeded();
-		
+
 		// Wait for ProfilePage Schema section
 		await expect(yoastSidebar.locator('text=ProfilePage Schema')).toBeVisible();
 
@@ -132,7 +131,7 @@ test.describe('ProfilePage Schema', () => {
 		// Check that search results appear
 		const searchResults = yoastSidebar.locator('.dc23-user-search-results');
 		await expect(searchResults).toBeVisible({ timeout: 3000 });
-		
+
 		// Check that our test user appears in results
 		await expect(yoastSidebar.locator('text=Test Profile User')).toBeVisible();
 	});
@@ -144,17 +143,17 @@ test.describe('ProfilePage Schema', () => {
 		await yoastButton.click();
 
 		const yoastSidebar =	page.getByRole('region', { name: 'Editor settings' });
-		
+
 		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		await schemaTab.scrollIntoViewIfNeeded();
-		
+
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 		await pageTypeSelect.scrollIntoViewIfNeeded();
-		
+
 		// Search for user
 		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();
 		await searchInput.fill('Test Profile');
@@ -173,10 +172,10 @@ test.describe('ProfilePage Schema', () => {
 
 		// Verify the meta was saved by reloading and checking
 		await page.reload();
-		
+
 		// Wait for editor to load
 		await page.waitForLoadState('domcontentloaded');
-		
+
 		// Open Yoast SEO and Schema tab again
 		const yoastButtonReload = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButtonReload.waitFor({ state: 'visible', timeout: 5000 });
@@ -200,17 +199,17 @@ test.describe('ProfilePage Schema', () => {
 		await yoastButton.click();
 
 		const yoastSidebar =	page.getByRole('region', { name: 'Editor settings' });
-		
+
 		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		await schemaTab.scrollIntoViewIfNeeded();
-		
+
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
 		await pageTypeSelect.scrollIntoViewIfNeeded();
-		
+
 		// Search and select user
 		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();
 		await searchInput.fill('Test Profile');
@@ -222,7 +221,7 @@ test.describe('ProfilePage Schema', () => {
 		// Check that user info is displayed
 		const userProfile = yoastSidebar.locator('.dc23-user-profile');
 		await expect(userProfile).toBeVisible();
-		
+
 		// Check for name
 		await expect(userProfile.locator('text=Name:')).toBeVisible();
 		await expect(userProfile).toContainText('Test Profile User');
@@ -235,12 +234,12 @@ test.describe('ProfilePage Schema', () => {
 		await yoastButton.click();
 
 		const yoastSidebar =	page.getByRole('region', { name: 'Editor settings' });
-		
+
 		const schemaTab = yoastSidebar.locator('button:has-text("Schema")').first();
 		await schemaTab.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTab.click();
 		await schemaTab.scrollIntoViewIfNeeded();
-		
+
 		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
 		await pageTypeSelect.selectOption('ProfilePage');
@@ -267,7 +266,7 @@ test.describe('ProfilePage Schema', () => {
 	test('only shows for pages, not posts', async ({ admin, page }) => {
 		// Create a regular post instead of a page
 		await admin.createNewPost({ postType: 'post' });
-		
+
 		// Close any modal that might appear
 		const closeButton = page.locator('button[aria-label="Close"]').first();
 		if (await closeButton.isVisible({ timeout: 2000 }).catch(() => false)) {
@@ -286,16 +285,16 @@ test.describe('ProfilePage Schema', () => {
 		if (await schemaTab.isVisible()) {
 			await schemaTab.click();
 			await schemaTab.scrollIntoViewIfNeeded();
-		
+
 			// Try to set article type to ProfilePage (if the option even exists for posts)
 			const pageTypeSelect = yoastSidebar.getByLabel('Page type');
 			await pageTypeSelect.scrollIntoViewIfNeeded();
 			if (await pageTypeSelect.isVisible()) {
 				const hasProfilePage = await pageTypeSelect.locator('option[value="ProfilePage"]').count();
-				
+
 				if (hasProfilePage > 0) {
 					await pageTypeSelect.selectOption('ProfilePage');
-					
+
 					// ProfilePage Schema section should still not appear for posts
 					await expect(yoastSidebar.locator('text=ProfilePage Schema')).not.toBeVisible({ timeout: 2000 });
 				}

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -178,7 +178,7 @@ test.describe('ProfilePage Schema', () => {
 		await page.waitForLoadState('domcontentloaded');
 
 		// Close the patterns modal if it appears
-		const patternModalTitle = page.locateByText('Choose a pattern').first();
+		const patternModalTitle = page.getByText('Choose a pattern').first();
 		if (await patternModalTitle.isVisible({ timeout: 2000 }).catch(() => false)) {
 			await page.keyboard.press('Escape');
 		}

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -62,7 +62,7 @@ test.describe('ProfilePage Schema', () => {
 		}
 
 		// Check that ProfilePage Schema section is not visible
-		await expect(page.locator('text=ProfilePage Schema')).not.toBeVisible({ timeout: 2000 });
+		await expect(page.locator('button:has-text("ProfilePage Schema")')).not.toBeVisible({ timeout: 2000 });
 	});
 
 	test('ProfilePage Schema section appears when page type is ProfilePage', async ({ page }) => {
@@ -85,7 +85,7 @@ test.describe('ProfilePage Schema', () => {
 		await page.keyboard.press('Tab');
 
 		// Wait for ProfilePage Schema section to appear
-		const portfolioTab = yoastSidebar.locator('text=ProfilePage Schema');
+		const portfolioTab = yoastSidebar.locator('button:has-text("ProfilePage Schema")');
 		await expect(portfolioTab).toBeVisible({ timeout: 5000 });
 	});
 
@@ -108,7 +108,8 @@ test.describe('ProfilePage Schema', () => {
 		await page.keyboard.press('Tab');
 
 		// Wait for ProfilePage Schema section
-		await expect(yoastSidebar.locator('text=ProfilePage Schema')).toBeVisible();
+		const portfolioTab = yoastSidebar.locator('button:has-text("ProfilePage Schema")');
+		await expect(portfolioTab).toBeVisible();
 
 		// Find the search input
 		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -177,6 +177,12 @@ test.describe('ProfilePage Schema', () => {
 		// Wait for editor to load
 		await page.waitForLoadState('domcontentloaded');
 
+		// Close the patterns modal if it appears
+		const closeButton = page.locator('button[aria-label="Close"]').first();
+		if (await closeButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+			await closeButton.click();
+		}
+
 		// Open Yoast SEO and Schema tab again
 		const yoastButtonReload = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButtonReload.waitFor({ state: 'visible', timeout: 5000 });

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -191,7 +191,7 @@ test.describe('ProfilePage Schema', () => {
 
 		const yoastSidebarReload =	page.getByRole('region', { name: 'Editor settings' });
 
-		const schemaTabReload = yoastSidebarReload.locator('button:has-text("Schema")').first();
+		const schemaTabReload = yoastSidebarReload.locator('button:has-text("ProfilePage Schema")').first();
 		await schemaTabReload.waitFor({ state: 'visible', timeout: 5000 });
 		await schemaTabReload.click();
 

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -226,7 +226,7 @@ test.describe('ProfilePage Schema', () => {
 		await expect(userProfile).toContainText('Test Profile User');
 	});
 
-	test.skip('clears search results after user selection', async ({ page }) => {
+	test('clears search results after user selection', async ({ page }) => {
 		// Open Yoast SEO sidebar and set page type to ProfilePage
 		const yoastButton = page.locator('button[aria-label*="Yoast"]').first();
 		await yoastButton.waitFor({ state: 'visible', timeout: 5000 });
@@ -239,9 +239,11 @@ test.describe('ProfilePage Schema', () => {
 		await schemaTab.click();
 		await schemaTab.scrollIntoViewIfNeeded();
 
-		const pageTypeSelect = yoastSidebar.getByLabel('Page type');
-		await pageTypeSelect.waitFor({ state: 'visible', timeout: 5000 });
-		await pageTypeSelect.selectOption('ProfilePage');
+		// Change page type to ProfilePage
+		await yoastSidebar.getByRole('combobox', { name: 'Page type' }).click();
+		await page.keyboard.type('profi');
+		await page.keyboard.press('Tab');
+		await page.keyboard.press('Tab');
 
 		// Search for user
 		const searchInput = yoastSidebar.locator('input[placeholder*="Search for a user"]').first();

--- a/specs/profilepage-schema.spec.js
+++ b/specs/profilepage-schema.spec.js
@@ -83,6 +83,7 @@ test.describe('ProfilePage Schema', () => {
 		await page.getByRole('combobox', { name: 'Page type' }).click();
 		await page.keyboard.type('profi');
 		await page.keyboard.press('Tab');
+		await page.keyboard.press('Tab');
 
 		// Wait for ProfilePage Schema section to appear
 		const portfolioTab = yoastSidebar.locator('button:has-text("ProfilePage Schema")');
@@ -105,6 +106,7 @@ test.describe('ProfilePage Schema', () => {
 		// Change page type to ProfilePage
 		await page.getByRole('combobox', { name: 'Page type' }).click();
 		await page.keyboard.type('profi');
+		await page.keyboard.press('Tab');
 		await page.keyboard.press('Tab');
 
 		// Wait for ProfilePage Schema section

--- a/specs/socials-block.spec.js
+++ b/specs/socials-block.spec.js
@@ -32,7 +32,7 @@ test.describe('Author Socials block', () => {
     await page.getByLabel('YouTube profile URL').fill('');
     await page.getByRole('button', { name: 'Update Profile' }).click();
 
-    if (consoleLogs.length > 0) {
+    if (debug && consoleLogs.length > 0) {
       console.log('Page logs:', consoleLogs);
     }
     page.removeAllListeners('console');

--- a/specs/socials-block.spec.js
+++ b/specs/socials-block.spec.js
@@ -2,6 +2,7 @@ const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
 
 test.describe('Author Socials block', () => {
   let consoleLogs = [];
+  const debug = false;
   
   const setBasicSocials = async ( { admin, page } ) => {
     // setup author with social profiles first

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-37-/**
+/**
  * WordPress dependencies
  */
 import { render, useState, useEffect } from '@wordpress/element';

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,9 @@ function ProfilePageSchemaSection() {
 	// Get the page type from Yoast SEO
 	const { pageType } = useSelect((select) => {
 		const yoastStore = select('yoast-seo/editor');
+		
+		console.log( Object.keys( yoastStore ) );
+		
 		return {
 			pageType: yoastStore.getPageType(),
 		};

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,6 @@ function ProfilePageSchemaSection() {
 	const { pageType } = useSelect((select) => {
 		const yoastStore = select('yoast-seo/editor');
 		
-		console.log( Object.keys( yoastStore ) );
-		
 		return {
 			pageType: yoastStore.getPageType(),
 		};

--- a/src/index.js
+++ b/src/index.js
@@ -20,22 +20,21 @@ function ProfilePageSchemaSection() {
 	const [userProfile, setUserProfile] = useState(null);
 
 	// Get the page type from Yoast SEO
-	const pageType = useSelect((select) => {
-		// Check if Yoast SEO store is available
+	const { pageType } = useSelect((select) => {
 		const yoastStore = select('yoast-seo/editor');
-		return yoastStore ? yoastStore.getPageType() : null;
+		return {
+			pageType: yoastStore.getPageType(),
+		};
 	}, []);
 
 	// Get current post type
-	const postType = useSelect(
-		(select) => select(editorStore).getCurrentPostType(),
-		[]
-	);
-
-	const savedUserId = useSelect(
-		(select) => select(editorStore).getEditedPostAttribute('meta')?._dc23_portfolio_user_id,
-		[]
-	);
+	const { postType, savedUserId } = useSelect((select) => {
+		const store = select(editorStore);
+		return {
+			postType: store.getCurrentPostType(),
+			savedUserId: store.getEditedPostAttribute('meta')?._dc23_portfolio_user_id,
+		};
+	}, [] );
 
 	const { editPost } = useDispatch(editorStore);
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,11 +20,12 @@ function ProfilePageSchemaSection() {
 	const [userProfile, setUserProfile] = useState(null);
 
 	// Get the page type from Yoast SEO
-	const { pageType } = useSelect((select) => {
+	const { pageType, defaultPageType } = useSelect((select) => {
 		const yoastStore = select('yoast-seo/editor');
 		
 		return {
 			pageType: yoastStore.getPageType(),
+			defaultPageType: yoastStore.getDefaultPageType(),
 		};
 	}, []);
 
@@ -47,7 +48,7 @@ function ProfilePageSchemaSection() {
 	}, [savedUserId]);
 
 	// Only show this section when post type is page and page type is ProfilePage
-	console.log({postType, pageType});
+	console.log({postType, pageType, defaultPageType});
 	if (postType !== 'page' || pageType !== 'ProfilePage') {
 		return null;
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -47,8 +47,9 @@ function ProfilePageSchemaSection() {
 	}, [savedUserId]);
 
 	// Only show this section when post type is page and page type is ProfilePage
+	console.log({postType, articleType});
 	if (postType !== 'page' || articleType !== 'ProfilePage') {
-		return null;
+		// return null;
 	}
 
 	// Search for users

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,184 @@
+37-/**
+ * WordPress dependencies
+ */
+import { render, useState, useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { Fill } from '@wordpress/components';
+import { SearchControl, PanelBody, Spinner } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { store as editorStore } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * ProfilePage Schema Section Component
+ */
+function ProfilePageSchemaSection() {
+	const [searchTerm, setSearchTerm] = useState('');
+	const [users, setUsers] = useState([]);
+	const [isLoading, setIsLoading] = useState(false);
+	const [selectedUser, setSelectedUser] = useState(null);
+	const [userProfile, setUserProfile] = useState(null);
+
+	// Get the article type from Yoast SEO
+	const articleType = useSelect((select) => {
+		// Check if Yoast SEO store is available
+		const yoastStore = select('yoast-seo/editor');
+		return yoastStore ? yoastStore.getArticleType() : null;
+	}, []);
+
+	// Get current post ID and meta
+	const postId = useSelect(
+		(select) => select(editorStore).getCurrentPostId(),
+		[]
+	);
+
+	const savedUserId = useSelect(
+		(select) => select(editorStore).getEditedPostAttribute('meta')?._dc23_portfolio_user_id,
+		[]
+	);
+
+	const { editPost } = useDispatch(editorStore);
+
+	// Load saved user when component mounts
+	useEffect(() => {
+		if (savedUserId) {
+			loadUserProfile(savedUserId);
+		}
+	}, [savedUserId]);
+
+	// Only show this section when page type is ProfilePage
+	if (articleType !== 'ProfilePage') {
+		return null;
+	}
+
+	// Search for users
+	const searchUsers = async (search) => {
+		if (!search || search.length < 2) {
+			setUsers([]);
+			return;
+		}
+
+		setIsLoading(true);
+		try {
+			const results = await apiFetch({
+				path: `/wp/v2/users?search=${encodeURIComponent(search)}&per_page=10`,
+			});
+			setUsers(results);
+		} catch (error) {
+			console.error('Error searching users:', error);
+			setUsers([]);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	// Load full user profile
+	const loadUserProfile = async (userId) => {
+		try {
+			const user = await apiFetch({
+				path: `/wp/v2/users/${userId}?context=edit`,
+			});
+			setSelectedUser(user);
+			setUserProfile(user);
+			setSearchTerm(user.name);
+		} catch (error) {
+			console.error('Error loading user profile:', error);
+		}
+	};
+
+	// Handle user selection
+	const handleUserSelect = (userId) => {
+		// Save to post meta
+		editPost({
+			meta: {
+				_dc23_portfolio_user_id: userId,
+			},
+		});
+
+		// Load user profile
+		loadUserProfile(userId);
+
+		// Clear search results
+		setUsers([]);
+	};
+
+	// Handle search input change
+	const handleSearchChange = (value) => {
+		setSearchTerm(value);
+		searchUsers(value);
+	};
+
+	return (
+		<Fill name="YoastSidebar" priority={28}>
+			<PanelBody
+				title={__('ProfilePage Schema', 'dc23-portfolio')}
+				initialOpen={true}
+			>
+				<div className="dc23-profile-schema">
+					<SearchControl
+						label={__('Select User Profile', 'dc23-portfolio')}
+						value={searchTerm}
+						onChange={handleSearchChange}
+						placeholder={__('Search for a user...', 'dc23-portfolio')}
+						help={__('Select the main user profile for this page.', 'dc23-portfolio')}
+					/>
+
+					{isLoading && <Spinner />}
+
+					{users.length > 0 && (
+						<ul className="dc23-user-search-results">
+							{users.map((user) => (
+								<li key={user.id}>
+									<button
+										type="button"
+										onClick={() => handleUserSelect(user.id)}
+										className="dc23-user-select-button"
+									>
+										{user.name}
+									</button>
+								</li>
+							))}
+						</ul>
+					)}
+
+					{userProfile && (
+						<div className="dc23-user-profile">
+							<h4>{__('Selected Profile', 'dc23-portfolio')}</h4>
+							<div className="dc23-user-info">
+								<p>
+									<strong>{__('Name:', 'dc23-portfolio')}</strong>{' '}
+									{userProfile.name}
+								</p>
+								{userProfile.wpseo_title && (
+									<p>
+										<strong>{__('Title:', 'dc23-portfolio')}</strong>{' '}
+										{userProfile.wpseo_title}
+									</p>
+								)}
+								{userProfile.wpseo_pronouns && (
+									<p>
+										<strong>{__('Pronouns:', 'dc23-portfolio')}</strong>{' '}
+										{userProfile.wpseo_pronouns}
+									</p>
+								)}
+								{userProfile.wpseo_employer && (
+									<p>
+										<strong>{__('Employer:', 'dc23-portfolio')}</strong>{' '}
+										{userProfile.wpseo_employer}
+									</p>
+								)}
+							</div>
+						</div>
+					)}
+				</div>
+			</PanelBody>
+		</Fill>
+	);
+}
+
+// Mount the component
+if (window.wp && window.wp.element) {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	render(<ProfilePageSchemaSection />, container);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ function ProfilePageSchemaSection() {
 	// Only show this section when post type is page and page type is ProfilePage
 	console.log({postType, articleType});
 	if (postType !== 'page' || articleType !== 'ProfilePage') {
-		// return null;
+		return null;
 	}
 
 	// Search for users

--- a/src/index.js
+++ b/src/index.js
@@ -32,12 +32,6 @@ function ProfilePageSchemaSection() {
 		[]
 	);
 
-	// Get current post ID and meta
-	const postId = useSelect(
-		(select) => select(editorStore).getCurrentPostId(),
-		[]
-	);
-
 	const savedUserId = useSelect(
 		(select) => select(editorStore).getEditedPostAttribute('meta')?._dc23_portfolio_user_id,
 		[]

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { render, useState, useEffect } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Fill } from '@wordpress/components';
-import { SearchControl, PanelBody, Spinner } from '@wordpress/components';
+import { registerPlugin } from '@wordpress/plugins';
+import { Fill, PanelBody, SearchControl, Spinner } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
@@ -26,6 +26,12 @@ function ProfilePageSchemaSection() {
 		return yoastStore ? yoastStore.getArticleType() : null;
 	}, []);
 
+	// Get current post type
+	const postType = useSelect(
+		(select) => select(editorStore).getCurrentPostType(),
+		[]
+	);
+
 	// Get current post ID and meta
 	const postId = useSelect(
 		(select) => select(editorStore).getCurrentPostId(),
@@ -46,8 +52,8 @@ function ProfilePageSchemaSection() {
 		}
 	}, [savedUserId]);
 
-	// Only show this section when page type is ProfilePage
-	if (articleType !== 'ProfilePage') {
+	// Only show this section when post type is page and page type is ProfilePage
+	if (postType !== 'page' || articleType !== 'ProfilePage') {
 		return null;
 	}
 
@@ -109,7 +115,7 @@ function ProfilePageSchemaSection() {
 	};
 
 	return (
-		<Fill name="YoastSidebar" priority={28}>
+		<Fill name="YoastSidebar">
 			<PanelBody
 				title={__('ProfilePage Schema', 'dc23-portfolio')}
 				initialOpen={true}
@@ -176,9 +182,7 @@ function ProfilePageSchemaSection() {
 	);
 }
 
-// Mount the component
-if (window.wp && window.wp.element) {
-	const container = document.createElement('div');
-	document.body.appendChild(container);
-	render(<ProfilePageSchemaSection />, container);
-}
+// Register the plugin
+registerPlugin('dc23-profile-page-schema', {
+	render: ProfilePageSchemaSection,
+});

--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,11 @@ function ProfilePageSchemaSection() {
 	const [selectedUser, setSelectedUser] = useState(null);
 	const [userProfile, setUserProfile] = useState(null);
 
-	// Get the article type from Yoast SEO
-	const articleType = useSelect((select) => {
+	// Get the page type from Yoast SEO
+	const pageType = useSelect((select) => {
 		// Check if Yoast SEO store is available
 		const yoastStore = select('yoast-seo/editor');
-		return yoastStore ? yoastStore.getArticleType() : null;
+		return yoastStore ? yoastStore.getPageType() : null;
 	}, []);
 
 	// Get current post type
@@ -47,8 +47,8 @@ function ProfilePageSchemaSection() {
 	}, [savedUserId]);
 
 	// Only show this section when post type is page and page type is ProfilePage
-	console.log({postType, articleType});
-	if (postType !== 'page' || articleType !== 'ProfilePage') {
+	console.log({postType, pageType});
+	if (postType !== 'page' || pageType !== 'ProfilePage') {
 		return null;
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ function ProfilePageSchemaSection() {
 	}, [savedUserId]);
 
 	// Only show this section when post type is page and page type is ProfilePage
-	console.warn({postType, pageType, defaultPageType});
+	console.error({postType, pageType, defaultPageType, savedUserId});
 	if (postType !== 'page' || pageType !== 'ProfilePage') {
 		return null;
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ function ProfilePageSchemaSection() {
 	}, [savedUserId]);
 
 	// Only show this section when post type is page and page type is ProfilePage
-	console.log({postType, pageType, defaultPageType});
+	console.warn({postType, pageType, defaultPageType});
 	if (postType !== 'page' || pageType !== 'ProfilePage') {
 		return null;
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const PanelBodyWithRenderPriority = ({ renderPriority, ...props }) => ( <PanelBo
 /**
  * ProfilePage Schema Section Component
  */
-function ProfilePageSchemaSection() {
+function ProfilePageSchemaContent() {
 	const [searchTerm, setSearchTerm] = useState('');
 	const [users, setUsers] = useState([]);
 	const [isLoading, setIsLoading] = useState(false);
@@ -114,9 +114,7 @@ function ProfilePageSchemaSection() {
 	console.error({savedUserId});
 
 	return (
-		<Fill name="YoastSidebar">
-			<PanelBodyWithRenderPriority
-					renderPriority={ 28.1 }
+			<PanelBody
 				title={__('ProfilePage Schema', 'dc23-portfolio')}
 				initialOpen={true}
 			>
@@ -177,10 +175,19 @@ function ProfilePageSchemaSection() {
 						</div>
 					)}
 				</div>
-			</PanelBodyWithRenderPriority>
-		</Fill>
+			</PanelBody>
 	);
 }
+
+const ProfilePageSchemaSection = () => {
+	return (
+		<Fill name="YoastSidebar">
+			<div renderPriority={ 28.1 }>
+				<ProfilePageSchemaContent />
+			</div>
+		</Fill>
+	);
+};
 
 // Register the plugin
 registerPlugin('dc23-profile-page-schema', {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ import apiFetch from '@wordpress/api-fetch';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
+const PanelBodyWithRenderPriority = ({ renderPriority, ...props }) => ( <PanelBody {...props} /> );
+
 /**
  * ProfilePage Schema Section Component
  */
@@ -22,7 +24,7 @@ function ProfilePageSchemaSection() {
 	// Get the page type from Yoast SEO
 	const { pageType, defaultPageType } = useSelect((select) => {
 		const yoastStore = select('yoast-seo/editor');
-		
+
 		return {
 			pageType: yoastStore.getPageType(),
 			defaultPageType: yoastStore.getDefaultPageType(),
@@ -112,7 +114,8 @@ function ProfilePageSchemaSection() {
 
 	return (
 		<Fill name="YoastSidebar">
-			<PanelBody
+			<PanelBodyWithRenderPriority
+					renderPriority={ 28.1 }
 				title={__('ProfilePage Schema', 'dc23-portfolio')}
 				initialOpen={true}
 			>
@@ -173,7 +176,7 @@ function ProfilePageSchemaSection() {
 						</div>
 					)}
 				</div>
-			</PanelBody>
+			</PanelBodyWithRenderPriority>
 		</Fill>
 	);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,6 @@ function ProfilePageSchemaSection() {
 	}, [savedUserId]);
 
 	// Only show this section when post type is page and page type is ProfilePage
-	console.error({postType, pageType, defaultPageType, savedUserId});
 	if (postType !== 'page' || pageType !== 'ProfilePage') {
 		return null;
 	}
@@ -111,6 +110,8 @@ function ProfilePageSchemaSection() {
 		setSearchTerm(value);
 		searchUsers(value);
 	};
+	
+	console.error({savedUserId});
 
 	return (
 		<Fill name="YoastSidebar">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,10 @@
+const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const path = require('path');
+
+module.exports = {
+	...defaultConfig,
+	entry: {
+		...defaultConfig.entry(),
+		index: path.resolve(process.cwd(), 'src', 'index.js'),
+	}
+};


### PR DESCRIPTION
Introduce functionality for the ProfilePage schema, allowing user selection and registration of associated post meta. This update enhances the schema output by including user details in the WebPage schema and adds a user selection interface in the editor.